### PR TITLE
Make MessageFormat.format parsing optional when logging

### DIFF
--- a/java/connector-framework/src/main/java/org/identityconnectors/common/logging/Log.java
+++ b/java/connector-framework/src/main/java/org/identityconnectors/common/logging/Log.java
@@ -203,7 +203,7 @@ public final class Log {
             final Object... args) {
         if (isLoggable(level)) {
             String message = format;
-            if (format != null && args != null) {
+            if (format != null && args != null && args.length > 0) {
                 // consider using thread local pattern to cache these for
                 // performance the pattern will always may always changed.
                 message = MessageFormat.format(format, args);


### PR DESCRIPTION
Log.log parses every message with MessageFormat.format because it interprets empty args as non empty (tricky java ellipsis semantics).

Checking args.length fixes that.