### PR TITLE
Fix allowedValues being lost during APIConfiguration clone

### DIFF
--- a/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/serializer/APIConfigurationHandlers.java
+++ b/java/connector-framework-internal/src/main/java/org/identityconnectors/framework/impl/serializer/APIConfigurationHandlers.java
@@ -33,6 +33,7 @@ import org.identityconnectors.common.pooling.ObjectPoolConfiguration;
 import org.identityconnectors.framework.api.ConnectorKey;
 import org.identityconnectors.framework.api.ResultsHandlerConfiguration;
 import org.identityconnectors.framework.api.operations.APIOperation;
+import org.identityconnectors.framework.common.objects.SuggestedValues;
 import org.identityconnectors.framework.impl.api.APIConfigurationImpl;
 import org.identityconnectors.framework.impl.api.ConfigurationPropertiesImpl;
 import org.identityconnectors.framework.impl.api.ConfigurationPropertyImpl;
@@ -132,6 +133,7 @@ class APIConfigurationHandlers {
                 @SuppressWarnings("unchecked")
                 Set<Class<? extends APIOperation>> ops = (Set) decoder.readObjectField("operations", Set.class, null);
                 rv.setOperations(ops);
+                rv.setAllowedValues((SuggestedValues) decoder.readObjectField("allowedValues", SuggestedValues.class, null));
                 return rv;
             }
 
@@ -148,6 +150,7 @@ class APIConfigurationHandlers {
                 encoder.writeClassField("type", val.getType());
                 encoder.writeObjectField("value", val.getValue(), false);
                 encoder.writeObjectField("operations", val.getOperations(), true);
+                encoder.writeObjectField("allowedValues", val.getAllowedValues(), true);
             }
         });
 

--- a/java/connector-framework-internal/src/test/java/org/identityconnectors/framework/impl/api/ConnectorInfoManagerTestBase.java
+++ b/java/connector-framework-internal/src/test/java/org/identityconnectors/framework/impl/api/ConnectorInfoManagerTestBase.java
@@ -185,6 +185,12 @@ public abstract class ConnectorInfoManagerTestBase {
         assertTrue(operations.contains(SyncApiOp.class));
         assertTrue(operations.contains(LiveSyncApiOp.class));
 
+        SuggestedValues allowedValues = property.getAllowedValues();
+        assertNotNull(allowedValues);
+        assertEquals(2, allowedValues.getValues().size());
+        assertTrue(allowedValues.getValues().contains("value1"));
+        assertTrue(allowedValues.getValues().contains("value2"));
+
         CurrentLocale.clear();
         assertEquals("Help for test field.", property.getHelpMessage(null));
         assertEquals("Display for test field.", property.getDisplayName(null));

--- a/java/connector-framework-internal/src/test/java/org/identityconnectors/framework/impl/serializer/ObjectSerializationTests.java
+++ b/java/connector-framework-internal/src/test/java/org/identityconnectors/framework/impl/serializer/ObjectSerializationTests.java
@@ -426,6 +426,7 @@ public class ObjectSerializationTests {
         v1.setValue("bar");
         v1.setType(String.class);
         v1.setOperations(FrameworkUtil.allAPIOperations());
+        v1.setAllowedValues(SuggestedValuesBuilder.build("opt1", "opt2"));
 
         ConfigurationPropertyImpl v2 = (ConfigurationPropertyImpl) cloneObject(v1);
         assertEquals(1, v2.getOrder());
@@ -438,6 +439,8 @@ public class ObjectSerializationTests {
         assertEquals("bar", v2.getValue());
         assertEquals(String.class, v2.getType());
         assertEquals(FrameworkUtil.allAPIOperations(), v2.getOperations());
+        assertNotNull(v2.getAllowedValues());
+        assertEquals(CollectionUtil.newList("opt1", "opt2"), v2.getAllowedValues().getValues());
     }
 
     @Test

--- a/java/testbundlev1/src/main/java/org/identityconnectors/testconnector/TstConnectorConfig.java
+++ b/java/testbundlev1/src/main/java/org/identityconnectors/testconnector/TstConnectorConfig.java
@@ -59,7 +59,7 @@ public class TstConnectorConfig extends AbstractConfiguration {
         resetConnectionCount = count;
     }
 
-    @ConfigurationProperty(operations = { SyncOp.class, LiveSyncOp.class })
+    @ConfigurationProperty(operations = { SyncOp.class, LiveSyncOp.class }, allowedValues = { "value1", "value2" })
     public String getTstField() {
         TstConnector.checkClassLoader();
         return tstField;


### PR DESCRIPTION
ConfigurationPropertyImpl serializer did not include the allowedValues field, causing it to be silently dropped by SerializerUtil.cloneObject(). Added serialization and deserialization of allowedValues in APIConfigurationHandlers. Added test coverage for the round-trip in ObjectSerializationTests and for the full annotation path in ConnectorInfoManagerTestBase/TstConnectorConfig.